### PR TITLE
throwing an error if parsing fails

### DIFF
--- a/lib/engine/engine.rb
+++ b/lib/engine/engine.rb
@@ -13,7 +13,10 @@ module Slippers
     def render(object_to_render=nil)
       parser = SlippersParser.new
       parse_tree = parser.parse(@main_template.template)
-      return '' unless parse_tree
+      if(parse_tree.nil?) 
+        raise Exception, "Parse error: #{parser.failure_reason}"
+      end
+
       parse_tree.eval(object_to_render, @template_group) 
     end
     

--- a/slippers.gemspec
+++ b/slippers.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |s|
   s.email = %q{me@sarahtaraporewalla.com}
   s.extra_rdoc_files = [
     "LICENSE",
-     "README"
+     "README.md"
   ]
   s.files = [
     "LICENSE",
-     "README",
+     "README.md",
      "Rakefile",
      "VERSION.yml",
      "examples/blog/README",


### PR DESCRIPTION
hi,

if parsing fails, slippers returns an empty string. 
This behavior is not really user friendly, especially if you deal with a big template.

I also fixed an issue in the gemspec with the renamed README.

Cheers Leon 
